### PR TITLE
Add video/audio effects

### DIFF
--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -128,6 +128,26 @@ parameters:
 
 ## Module: opentimelineio.schema
 
+### AudioFade.1
+
+parameters:
+- *duration*
+- *effect_name*
+- *enabled*
+- *fade_in*
+- *metadata*
+- *name*
+- *start_time*
+
+### AudioVolume.1
+
+parameters:
+- *effect_name*
+- *enabled*
+- *gain*
+- *metadata*
+- *name*
+
 ### Clip.2
 
 parameters:
@@ -252,9 +272,10 @@ parameters:
 - *metadata*
 - *name*
 
-### Timeline.1
+### Timeline.2
 
 parameters:
+- *canvas_size*
 - *global_start_time*
 - *metadata*
 - *name*
@@ -279,6 +300,47 @@ parameters:
 - *name*
 - *out_offset*
 - *transition_type*
+
+### VideoCrop.1
+
+parameters:
+- *bottom*
+- *effect_name*
+- *enabled*
+- *left*
+- *metadata*
+- *name*
+- *right*
+- *top*
+
+### VideoPosition.1
+
+parameters:
+- *effect_name*
+- *enabled*
+- *metadata*
+- *name*
+- *x*
+- *y*
+
+### VideoRotate.1
+
+parameters:
+- *angle*
+- *effect_name*
+- *enabled*
+- *metadata*
+- *name*
+
+### VideoScale.1
+
+parameters:
+- *effect_name*
+- *enabled*
+- *height*
+- *metadata*
+- *name*
+- *width*
 
 ### SchemaDef.1
 

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -274,6 +274,48 @@ parameters:
 
 ## Module: opentimelineio.schema
 
+### AudioFade.1
+
+*full module path*: `opentimelineio.schema.AudioFade`
+
+*documentation*:
+
+```
+
+An effect that defines an audio fade.
+If fade_in is true, audio is fading in from the start time for the duration
+If fade_in is false, the audio is fading out from the start time for the duration
+
+```
+
+parameters:
+- *duration*: Fade duration
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *fade_in*: Fade direction
+- *metadata*: 
+- *name*: 
+- *start_time*: Fade start time
+
+### AudioVolume.1
+
+*full module path*: `opentimelineio.schema.AudioVolume`
+
+*documentation*:
+
+```
+
+An effect that multiplies the audio volume by a given gain value
+
+```
+
+parameters:
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *gain*: Gain multiplier
+- *metadata*: 
+- *name*: 
+
 ### Clip.2
 
 *full module path*: `opentimelineio.schema.Clip`
@@ -614,7 +656,7 @@ parameters:
 - *metadata*: 
 - *name*: 
 
-### Timeline.1
+### Timeline.2
 
 *full module path*: `opentimelineio.schema.Timeline`
 
@@ -625,6 +667,7 @@ None
 ```
 
 parameters:
+- *canvas_size*: 
 - *global_start_time*: 
 - *metadata*: 
 - *name*: 
@@ -666,6 +709,89 @@ parameters:
 - *name*: 
 - *out_offset*: Amount of the next clip this transition overlaps, exclusive.
 - *transition_type*: Kind of transition, as defined by the :class:`Type` enum.
+
+### VideoCrop.1
+
+*full module path*: `opentimelineio.schema.VideoCrop`
+
+*documentation*:
+
+```
+
+An effect that crops video by a given amount of pixels on each side.
+
+```
+
+parameters:
+- *bottom*: 
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *left*: 
+- *metadata*: 
+- *name*: 
+- *right*: 
+- *top*: 
+
+### VideoPosition.1
+
+*full module path*: `opentimelineio.schema.VideoPosition`
+
+*documentation*:
+
+```
+
+An effect that positions video by a given offset in the frame.
+The position is the location of the top left of the image on the canvas
+
+```
+
+parameters:
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *metadata*: 
+- *name*: 
+- *x*: 
+- *y*: 
+
+### VideoRotate.1
+
+*full module path*: `opentimelineio.schema.VideoRotate`
+
+*documentation*:
+
+```
+
+An effect that rotates video by a given amount.
+The rotation is specified in degrees clockwise.
+
+```
+
+parameters:
+- *angle*: Rotation angle in degrees clockwise
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *metadata*: 
+- *name*: 
+
+### VideoScale.1
+
+*full module path*: `opentimelineio.schema.VideoScale`
+
+*documentation*:
+
+```
+
+An effect that scales video to the given dimensions.
+
+```
+
+parameters:
+- *effect_name*: 
+- *enabled*: If true, the Effect is applied. If false, the Effect is omitted.
+- *height*: Height to scale to
+- *metadata*: 
+- *name*: 
+- *width*: Width to scale to
 
 ### SchemaDef.1
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -32,11 +32,13 @@ set(OPENTIMELINEIO_HEADER_FILES
     timeline.h
     track.h
     trackAlgorithm.h
+    transformEffects.h
     transition.h
     typeRegistry.h
     unknownSchema.h
     vectorIndexing.h
-    version.h)
+    version.h
+    volumeEffects.h)
 
 add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB} 
     clip.cpp
@@ -69,9 +71,11 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
     timeline.cpp
     track.cpp
     trackAlgorithm.cpp
+    transformEffects.cpp
     transition.cpp
     typeRegistry.cpp
-    unknownSchema.cpp 
+    unknownSchema.cpp
+    volumeEffects.cpp
     CORE_VERSION_MAP.cpp
     ${OPENTIMELINEIO_HEADER_FILES})
 

--- a/src/opentimelineio/CORE_VERSION_MAP.cpp
+++ b/src/opentimelineio/CORE_VERSION_MAP.cpp
@@ -145,6 +145,8 @@ const label_to_schema_version_map CORE_VERSION_MAP{
     { "0.18.0.dev1",
       {
           { "Adapter", 1 },
+          { "AudioFade", 1 },
+          { "AudioVolume", 1 },
           { "Clip", 2 },
           { "Composable", 1 },
           { "Composition", 1 },
@@ -169,10 +171,14 @@ const label_to_schema_version_map CORE_VERSION_MAP{
           { "Stack", 1 },
           { "Test", 1 },
           { "TimeEffect", 1 },
-          { "Timeline", 1 },
+          { "Timeline", 2 },
           { "Track", 1 },
           { "Transition", 1 },
           { "UnknownSchema", 1 },
+          { "VideoCrop", 1 },
+          { "VideoPosition", 1 },
+          { "VideoRotate", 1 },
+          { "VideoScale", 1 },
       } },
     // {next}
 };

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -826,6 +826,14 @@ SerializableObject::Reader::read(
 
 bool
 SerializableObject::Reader::read(
+    std::string const&                   key,
+    std::optional<IMATH_NAMESPACE::V2d>* value)
+{
+    return _read_optional(key, value);
+}
+
+bool
+SerializableObject::Reader::read(
     std::string const&                     key,
     std::optional<IMATH_NAMESPACE::Box2d>* value)
 {

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -137,6 +137,8 @@ public:
         bool read(std::string const& key, std::optional<RationalTime>* dest);
         bool read(std::string const& key, std::optional<TimeRange>* dest);
         bool read(std::string const& key, std::optional<TimeTransform>* dest);
+        bool read(std::string const&             key,
+            std::optional<IMATH_NAMESPACE::V2d>* value);
         bool read(
             std::string const&                     key,
             std::optional<IMATH_NAMESPACE::Box2d>* value);
@@ -451,6 +453,9 @@ public:
         void write(std::string const& key, IMATH_NAMESPACE::Box2d value);
         void write(std::string const& key, std::optional<RationalTime> value);
         void write(std::string const& key, std::optional<TimeRange> value);
+        void write(
+            std::string const&                  key,
+            std::optional<IMATH_NAMESPACE::V2d> value);
         void write(
             std::string const&                    key,
             std::optional<IMATH_NAMESPACE::Box2d> value);

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -925,6 +925,15 @@ SerializableObject::Writer::write(
 }
 
 void
+SerializableObject::Writer::write(
+    std::string const&                  key,
+    std::optional<IMATH_NAMESPACE::V2d> value)
+{
+    _encoder_write_key(key);
+    value ? _encoder.write_value(*value) : _encoder.write_null_value();
+}
+
+void
 SerializableObject::Writer::write(std::string const& key, TimeTransform value)
 {
     _encoder_write_key(key);

--- a/src/opentimelineio/timeline.cpp
+++ b/src/opentimelineio/timeline.cpp
@@ -7,11 +7,13 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 Timeline::Timeline(
-    std::string const&          name,
-    std::optional<RationalTime> global_start_time,
-    AnyDictionary const&        metadata)
+    std::string const&                  name,
+    std::optional<RationalTime>         global_start_time,
+    std::optional<IMATH_NAMESPACE::V2d> canvas_size,
+    AnyDictionary const&                metadata)
     : SerializableObjectWithMetadata(name, metadata)
     , _global_start_time(global_start_time)
+    , _canvas_size(canvas_size)
     , _tracks(new Stack("tracks"))
 {}
 
@@ -29,6 +31,7 @@ Timeline::read_from(Reader& reader)
 {
     return reader.read("tracks", &_tracks)
            && reader.read_if_present("global_start_time", &_global_start_time)
+           && reader.read_if_present("canvas_size", &_canvas_size)
            && Parent::read_from(reader);
 }
 
@@ -37,6 +40,7 @@ Timeline::write_to(Writer& writer) const
 {
     Parent::write_to(writer);
     writer.write("global_start_time", _global_start_time);
+    writer.write("canvas_size", _canvas_size);
     writer.write("tracks", _tracks);
 }
 

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -20,7 +20,7 @@ public:
     struct Schema
     {
         static auto constexpr name   = "Timeline";
-        static int constexpr version = 1;
+        static int constexpr version = 2;
     };
 
     using Parent = SerializableObjectWithMetadata;
@@ -29,11 +29,13 @@ public:
     ///
     /// @param name The timeline name.
     /// @param global_start_time The global start time of the timeline.
+    /// @param canvas_size The dimensions of the target canvas
     /// @param metadata The metadata for the timeline.
     Timeline(
-        std::string const&          name              = std::string(),
-        std::optional<RationalTime> global_start_time = std::nullopt,
-        AnyDictionary const&        metadata          = AnyDictionary());
+        std::string const&                  name              = std::string(),
+        std::optional<RationalTime>         global_start_time = std::nullopt,
+        std::optional<IMATH_NAMESPACE::V2d> canvas_size       = std::nullopt,
+        AnyDictionary const&                metadata          = AnyDictionary());
 
     /// @brief Return the timeline stack.
     Stack* tracks() const noexcept { return _tracks; }
@@ -57,6 +59,19 @@ public:
     set_global_start_time(std::optional<RationalTime> const& global_start_time)
     {
         _global_start_time = global_start_time;
+    }
+
+    /// @brief Return the canvas size
+    std::optional<IMATH_NAMESPACE::V2d> canvas_size() const noexcept
+    {
+        return _canvas_size;
+    }
+
+    /// @brief Set the canvas size
+    void
+    set_canvas_size(std::optional<IMATH_NAMESPACE::V2d> const& canvas_size)
+    {
+        _canvas_size = canvas_size;
     }
 
     /// @brief Return the duration of the timeline.
@@ -116,8 +131,9 @@ protected:
     void write_to(Writer&) const override;
 
 private:
-    std::optional<RationalTime> _global_start_time;
-    Retainer<Stack>             _tracks;
+    std::optional<RationalTime>         _global_start_time;
+    std::optional<IMATH_NAMESPACE::V2d> _canvas_size;
+    Retainer<Stack>                     _tracks;
 };
 
 template <typename T>

--- a/src/opentimelineio/transformEffects.cpp
+++ b/src/opentimelineio/transformEffects.cpp
@@ -1,0 +1,58 @@
+#include "opentimelineio/transformEffects.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+bool VideoScale::read_from(Reader &reader)
+{
+    return reader.read("width", &_width)
+           && reader.read("height", &_height)
+           && Parent::read_from(reader);
+}
+
+void VideoScale::write_to(Writer &writer) const {
+    Parent::write_to(writer);
+    writer.write("width", _width);
+    writer.write("height", _height);
+}
+
+bool VideoCrop::read_from(Reader &reader)
+{
+    return reader.read("left", &_left)
+           && reader.read("right", &_right)
+           && reader.read("top", &_top)
+           && reader.read("bottom", &_bottom)
+           && Parent::read_from(reader);
+}
+
+void VideoCrop::write_to(Writer &writer) const {
+    Parent::write_to(writer);
+    writer.write("left", _left);
+    writer.write("right", _right);
+    writer.write("top", _top);
+    writer.write("bottom", _bottom);
+}
+
+bool VideoPosition::read_from(Reader &reader)
+{
+    return reader.read("x", &_x)
+           && reader.read("y", &_y)
+           && Parent::read_from(reader);
+}
+
+void VideoPosition::write_to(Writer &writer) const {
+    Parent::write_to(writer);
+    writer.write("x", _x);
+    writer.write("y", _y);
+}
+
+bool VideoRotate::read_from(Reader &reader)
+{
+    return reader.read("angle", &_angle)
+           && Parent::read_from(reader);
+}
+
+void VideoRotate::write_to(Writer &writer) const {
+    Parent::write_to(writer);
+    writer.write("angle", _angle);
+}
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/transformEffects.h
+++ b/src/opentimelineio/transformEffects.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include "opentimelineio/effect.h"
+#include "opentimelineio/version.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+/// @brief An scaling effect
+class VideoScale : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "VideoScale";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new scaling effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param width How much to scale the width by.
+    /// @param height How much to scale the height by.
+    /// @param metadata The metadata for the effect.
+    /// @param enabled Whether the effect is enabled.
+    VideoScale(
+        std::string const&   name        = std::string(),
+        int64_t              width       = 0,
+        int64_t              height      = 0,
+        AnyDictionary const& metadata    = AnyDictionary())
+        : Effect(name, Schema::name, metadata)
+        , _width(width)
+        , _height(height)
+    {}
+
+    int64_t width() const noexcept { return _width; }
+    int64_t height() const noexcept { return _height; }
+
+    void set_width(int64_t width) noexcept { _width = width; }
+    void set_height(int64_t height) noexcept { _height = height; }
+
+protected:
+
+    virtual ~VideoScale() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    int64_t _width;  ///< The scaled width
+    int64_t _height; ///< The scaled height
+};
+
+/// @brief An crop effect
+class VideoCrop : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "VideoCrop";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new crop effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param left The amount to crop from the left.
+    /// @param right The amount to crop from the right.
+    /// @param top The amount to crop from the top.
+    /// @param bottom The amount to crop from the bottom.
+    /// @param metadata The metadata for the effect.
+    /// @param enabled Whether the effect is enabled.
+    VideoCrop(
+        std::string const&   name        = std::string(),
+        int64_t              left        = 0,
+        int64_t              right       = 0,
+        int64_t              top         = 0,
+        int64_t              bottom      = 0,
+        AnyDictionary const& metadata    = AnyDictionary(),
+        bool                 enabled     = true)
+        : Effect(name, Schema::name, metadata, enabled)
+        , _left(left)
+        , _right(right)
+        , _top(top)
+        , _bottom(bottom)
+    {}
+
+    int64_t left() const noexcept { return _left; }
+    int64_t right() const noexcept { return _right; }
+    int64_t top() const noexcept { return _top; }
+    int64_t bottom() const noexcept { return _bottom; }
+
+    void set_left(int64_t left) noexcept { _left = left; }
+    void set_right(int64_t right) noexcept { _right = right; }
+    void set_top(int64_t top) noexcept { _top = top; }
+    void set_bottom(int64_t bottom) noexcept { _bottom = bottom; }
+
+protected:
+    virtual ~VideoCrop() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    int64_t _left;   ///< The amount to crop from the left.
+    int64_t _right;  ///< The amount to crop from the right.
+    int64_t _top;    ///< The amount to crop from the top.
+    int64_t _bottom; ///< The amount to crop from the bottom.
+};
+
+/// @brief An position effect
+class VideoPosition : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "VideoPosition";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new position effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param x Distance of top left corner from left edge of canvas
+    /// @param y Distance of top left corner from top edge of canvas
+    /// @param metadata The metadata for the effect.
+    /// @param enabled Whether the effect is enabled.
+    VideoPosition(
+        std::string const&   name        = std::string(),
+        int64_t              x           = 0,
+        int64_t              y           = 0,
+        AnyDictionary const& metadata    = AnyDictionary(),
+        bool                 enabled     = true)
+        : Effect(name, Schema::name, metadata, enabled)
+        , _x(x)
+        , _y(y)
+    {}
+
+    int64_t x() const noexcept { return _x; }
+    int64_t y() const noexcept { return _y; }
+
+    void set_x(int64_t x) noexcept { _x = x; }
+    void set_y(int64_t y) noexcept { _y = y; }
+
+protected:
+    virtual ~VideoPosition() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    int64_t _x; ///< The horizontal position.
+    int64_t _y; ///< The vertical position.
+};
+
+/// @brief An rotation effect
+class VideoRotate : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "VideoRotate";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new rotation effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param angle The amount of rotation, degrees clockwise
+    /// @param metadata The metadata for the effect.
+    /// @param enabled Whether the effect is enabled.
+    VideoRotate(
+        std::string const&   name        = std::string(),
+        double               angle      = 0.0,
+        AnyDictionary const& metadata    = AnyDictionary(),
+        bool                 enabled     = true)
+        : Effect(name, Schema::name, metadata, enabled)
+        , _angle(angle)
+    {}
+
+    double angle() const noexcept { return _angle; }
+    void set_angle(double angle) noexcept { _angle = angle; }
+
+protected:
+    virtual ~VideoRotate() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    double _angle; ///< The angle of rotation, degrees clockwise
+};
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -25,8 +25,10 @@
 #include "opentimelineio/timeEffect.h"
 #include "opentimelineio/timeline.h"
 #include "opentimelineio/track.h"
+#include "opentimelineio/transformEffects.h"
 #include "opentimelineio/transition.h"
 #include "opentimelineio/unknownSchema.h"
+#include "opentimelineio/volumeEffects.h"
 #include "stringUtils.h"
 
 #include <assert.h>
@@ -53,6 +55,9 @@ TypeRegistry::TypeRegistry()
             return nullptr;
         },
         "UnknownSchema");
+
+    register_type<AudioVolume>();
+    register_type<AudioFade>();
 
     register_type<Clip>();
     register_type<Composable>();
@@ -86,6 +91,12 @@ TypeRegistry::TypeRegistry()
     register_type<Timeline>();
     register_type<Track>();
     register_type_from_existing_type("Sequence", 1, "Track", nullptr);
+
+    register_type<VideoCrop>();
+    register_type<VideoScale>();
+    register_type<VideoPosition>();
+    register_type<VideoRotate>();
+
     register_type<Transition>();
 
     /*

--- a/src/opentimelineio/volumeEffects.cpp
+++ b/src/opentimelineio/volumeEffects.cpp
@@ -1,0 +1,29 @@
+#include "volumeEffects.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+bool AudioVolume::read_from(Reader& reader) {
+    return reader.read("gain",& _gain)
+        && Parent::read_from(reader);
+}
+
+void AudioVolume::write_to(Writer &writer) const {
+    Parent::write_to(writer);
+    writer.write("gain", _gain);
+}
+
+bool AudioFade::read_from(Reader& reader) {
+    return reader.read("fade_in", &_fade_in)
+        && reader.read("start_time", &_start_time)
+        && reader.read("duration", &_duration)
+        && Parent::read_from(reader);
+}
+
+void AudioFade::write_to(Writer& writer) const {
+    Parent::write_to(writer);
+    writer.write("fade_in", _fade_in);
+    writer.write("start_time", _start_time);
+    writer.write("duration", _duration);
+}
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/volumeEffects.h
+++ b/src/opentimelineio/volumeEffects.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "opentimelineio/effect.h"
+#include "opentimelineio/version.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+/// @brief Sets the audio volume
+class AudioVolume : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "AudioVolume";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new volume effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param gain Gain value
+    /// @param metadata The metadata for the effect.
+    /// @param enabled Whether the effect is enabled.
+    AudioVolume(
+        std::string const& name       = std::string(),
+        double gain                   = 1.0,
+        AnyDictionary const& metadata = AnyDictionary())
+        : Effect(name, Schema::name, metadata)
+        , _gain(gain)
+    {}
+
+    double gain() const noexcept { return _gain; }
+    void set_gain(double gain) noexcept { _gain = gain; }
+
+protected:
+
+    virtual ~AudioVolume() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    double _gain; ///< the gain
+};
+
+/// @brief Describes an audio fade effect
+class AudioFade : public Effect
+{
+public:
+    /// @brief This struct provides the Effect schema.
+    struct Schema
+    {
+        static auto constexpr name   = "AudioFade";
+        static int constexpr version = 1;
+    };
+
+    using Parent = Effect;
+
+    /// @brief Create a new audio fade effect.
+    ///
+    /// @param name The name of the effect object.
+    /// @param fade_in Whether this is a fade-in (true) or fade-out (false).
+    /// @param start_time The start time of the fade in seconds.
+    /// @param duration Duration of the fade in seconds.
+    /// @param metadata The metadata for the effect.
+    AudioFade(
+        std::string const&   name        = std::string(),
+        bool                 fade_in     = true,
+        double               start_time  = 0.0,
+        double               duration    = 0.0,
+        AnyDictionary const& metadata    = AnyDictionary())
+        : Effect(name, Schema::name, metadata)
+        , _fade_in(fade_in)
+        , _start_time(start_time)
+        , _duration(duration)
+    {}
+
+    bool fade_in() const noexcept { return _fade_in; }
+    void set_fade_in(bool fade_in) noexcept { _fade_in = fade_in; }
+
+    double start_time() const noexcept { return _start_time; }
+    void set_start_time(double start_time) noexcept { _start_time = start_time; }
+
+    double duration() const noexcept { return _duration; }
+    void set_duration(double duration) noexcept { _duration = duration; }
+
+protected:
+
+    virtual ~AudioFade() = default;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+    bool _fade_in;         ///< true for fade-in, false for fade-out
+    double _start_time;    ///< start time of the fade in seconds
+    double _duration;      ///< duration of the fade in seconds
+};
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -6,6 +6,8 @@
 """User facing classes."""
 
 from .. _otio import (
+    AudioFade,
+    AudioVolume,
     Box2d,
     Clip,
     Effect,
@@ -24,6 +26,10 @@ from .. _otio import (
     Track,
     Transition,
     V2d,
+    VideoCrop,
+    VideoPosition,
+    VideoRotate,
+    VideoScale,
 )
 
 MarkerColor = Marker.Color
@@ -56,6 +62,8 @@ def timeline_from_clips(clips):
     return Timeline(tracks=[trck])
 
 __all__ = [
+    'AudioFade',
+    'AudioVolume',
     'Box2d',
     'Clip',
     'Effect',
@@ -74,5 +82,9 @@ __all__ = [
     'Transition',
     'SchemaDef',
     'timeline_from_clips',
-    'V2d'
+    'V2d',
+    'VideoCrop',
+    'VideoPosition',
+    'VideoRotate',
+    'VideoScale',
 ]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,13 +15,13 @@ foreach(test ${tests_opentime})
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-list(APPEND tests_opentimelineio test_clip test_serialization test_serializableCollection test_stack_algo test_timeline test_track test_editAlgorithm)
+list(APPEND tests_opentimelineio test_clip test_serialization test_serializableCollection test_stack_algo test_timeline test_track test_editAlgorithm test_transform_effects test_volume_effects)
 foreach(test ${tests_opentimelineio})
     add_executable(${test} utils.h utils.cpp ${test}.cpp)
 
     target_link_libraries(${test} opentimelineio)
     set_target_properties(${test} PROPERTIES FOLDER tests)
-    add_test(NAME ${test} 
+    add_test(NAME ${test}
            COMMAND ${test}
            # Set the pwd to the source directory so we can load the samples
            # like the python tests do

--- a/tests/baselines/empty_timeline.json
+++ b/tests/baselines/empty_timeline.json
@@ -1,6 +1,7 @@
 {
-    "OTIO_SCHEMA" : "Timeline.1",
+    "OTIO_SCHEMA" : "Timeline.2",
     "global_start_time" : null,
+    "canvas_size" : null,
     "metadata" : {
         "comments"   : "adding some stuff to metadata to try out",
         "a number"   : 1.0

--- a/tests/sample_data/screening_example.otio
+++ b/tests/sample_data/screening_example.otio
@@ -1,5 +1,6 @@
 {
-    "OTIO_SCHEMA": "Timeline.1",
+    "OTIO_SCHEMA": "Timeline.2",
+    "canvas": null,
     "metadata": {},
     "name": "Example_Screening.01",
     "global_start_time": null,

--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -12,6 +12,7 @@
 #include <opentimelineio/freezeFrame.h>
 #include <opentimelineio/linearTimeWarp.h>
 #include <opentimelineio/marker.h>
+#include <opentimelineio/transformEffects.h>
 
 #include <iostream>
 
@@ -154,12 +155,21 @@ main(int argc, char** argv)
         using namespace otio;
 
         static constexpr auto time_scalar = 1.5;
+        static constexpr auto width = 1920;
+        static constexpr auto height = 1280;
 
         SerializableObject::Retainer<LinearTimeWarp> ltw(new LinearTimeWarp(
             LinearTimeWarp::Schema::name,
             LinearTimeWarp::Schema::name,
             time_scalar));
-        std::vector<Effect*> effects = { ltw };
+
+        SerializableObject::Retainer<VideoScale> vscl(
+            new VideoScale(
+                VideoScale::Schema::name,
+                100,
+                200));
+
+        std::vector<Effect*> effects = { ltw, vscl };
 
         static constexpr auto red = Marker::Color::red;
 
@@ -247,11 +257,15 @@ main(int argc, char** argv)
         clip->set_media_references({ { "cloud", ref4 } }, "cloud");
         assertEqual(clip->media_reference(), ref4.value);
 
-        // basic test for an effect
+        // basic test for effects
         assertEqual(clip->effects().size(), effects.size());
         auto effect = dynamic_cast<OTIO_NS::LinearTimeWarp*>(
-            clip->effects().front().value);
+            clip->effects()[0].value);
         assertEqual(effect->time_scalar(), time_scalar);
+        auto scale = dynamic_cast<OTIO_NS::VideoScale*>(
+            clip->effects()[1].value);
+        assertEqual(scale->width(), 100);
+        assertEqual(scale->height(), 200);
 
         // basic test for a marker
         assertEqual(clip->markers().size(), markers.size());

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -111,7 +111,7 @@ class OTIOStatTest(ConsoleTester, unittest.TestCase):
     def test_basic(self):
         sys.argv = ['otiostat', SCREENING_EXAMPLE_PATH]
         self.run_test()
-        self.assertIn("top level object: Timeline.1", sys.stdout.getvalue())
+        self.assertIn("top level object: Timeline.2", sys.stdout.getvalue())
 
 
 OTIOStatTest_ShellOut = CreateShelloutTest(OTIOStatTest)

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -6,6 +6,7 @@
 #include <opentimelineio/clip.h>
 #include <opentimelineio/timeline.h>
 #include <opentimelineio/track.h>
+#include <opentimelineio/transformEffects.h>
 #include <opentimelineio/serialization.h>
 #include <opentimelineio/serializableObject.h>
 #include <opentimelineio/serializableObjectWithMetadata.h>
@@ -13,6 +14,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace otime = opentime::OPENTIME_VERSION;
 namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
@@ -26,6 +28,10 @@ main(int argc, char** argv)
         "success with default indent", [] {
         otio::SerializableObject::Retainer<otio::Clip> cl =
             new otio::Clip();
+
+        otio::SerializableObject::Retainer<otio::Effect> vs =
+            new otio::VideoScale("scale", 1920, 1280);
+        cl->effects().push_back(vs);
         otio::SerializableObject::Retainer<otio::Track> tr =
             new otio::Track();
         tr->append_child(cl);
@@ -37,10 +43,11 @@ main(int argc, char** argv)
         auto output = tl.value->to_json_string(&err, {});
         assertFalse(otio::is_error(err));
         assertEqual(output.c_str(), R"CONTENT({
-    "OTIO_SCHEMA": "Timeline.1",
+    "OTIO_SCHEMA": "Timeline.2",
     "metadata": {},
     "name": "",
     "global_start_time": null,
+    "canvas_size": null,
     "tracks": {
         "OTIO_SCHEMA": "Stack.1",
         "metadata": {},
@@ -64,7 +71,17 @@ main(int argc, char** argv)
                         "metadata": {},
                         "name": "",
                         "source_range": null,
-                        "effects": [],
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "VideoScale.1",
+                                "metadata": {},
+                                "name": "scale",
+                                "effect_name": "VideoScale",
+                                "enabled": true,
+                                "width": 1920,
+                                "height": 1280
+                            }
+                        ],
                         "markers": [],
                         "enabled": true,
                         "media_references": {

--- a/tests/test_timeline_algo.py
+++ b/tests/test_timeline_algo.py
@@ -18,7 +18,8 @@ class TimelineTrimmingTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = otio.adapters.read_from_string(
             """
             {
-                "OTIO_SCHEMA": "Timeline.1",
+                "OTIO_SCHEMA": "Timeline.2",
+                "canvas_size": null,
                 "metadata": {},
                 "name": null,
                 "tracks": {
@@ -264,7 +265,8 @@ class TimelineTrimmingTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         expected = otio.adapters.read_from_string(
             """
             {
-                "OTIO_SCHEMA": "Timeline.1",
+                "OTIO_SCHEMA": "Timeline.2",
+                "canvas_size": null,
                 "metadata": {},
                 "name": null,
                 "tracks": {

--- a/tests/test_transform_effects.cpp
+++ b/tests/test_transform_effects.cpp
@@ -1,0 +1,189 @@
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/deserialization.h>
+#include <opentimelineio/externalReference.h>
+#include <opentimelineio/transformEffects.h>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+    tests.add_test("test_video_transform_read", [] {
+        using namespace otio;
+
+        otio::ErrorStatus              status;
+        SerializableObject::Retainer<> so =
+            SerializableObject::from_json_string(
+                R"(
+            {
+                "OTIO_SCHEMA": "Clip.1",
+                "media_reference": {
+                    "OTIO_SCHEMA": "ExternalReference.1",
+                    "target_url": "unit_test_url",
+                    "available_range": {
+                        "OTIO_SCHEMA": "TimeRange.1",
+                        "duration": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24,
+                            "value": 8
+                        },
+                        "start_time": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24,
+                            "value": 10
+                        }
+                    }
+                },
+                "effects": [
+                    {
+                        "OTIO_SCHEMA": "VideoScale.1",
+                        "name": "scale",
+                        "width": 100,
+                        "height": 120,
+                        "effect_name": "VideoScale",
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "VideoPosition.1",
+                        "name": "position",
+                        "x": 10,
+                        "y": 20,
+                        "effect_name": "VideoPosition",
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "VideoRotate.1",
+                        "name": "rotate",
+                        "angle": 45.5,
+                        "effect_name": "VideoRotate",
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "VideoCrop.1",
+                        "name": "crop",
+                        "left": 5,
+                        "right": 6,
+                        "top": 7,
+                        "bottom": 8,
+                        "effect_name": "VideoCrop",
+                        "enabled": true
+                    }
+                ]
+            })",
+                &status);
+
+        assertFalse(is_error(status));
+
+        const Clip* clip = dynamic_cast<const Clip*>(so.value);
+        assertNotNull(clip);
+
+        auto effects = clip->effects();
+        assertEqual(effects.size(), 4);
+
+        auto video_scale = dynamic_cast<const VideoScale*>(effects[0].value);
+        assertNotNull(video_scale);
+        assertEqual(video_scale->width(), 100);
+        assertEqual(video_scale->height(), 120);
+
+        auto video_position = dynamic_cast<const VideoPosition*>(effects[1].value);
+        assertNotNull(video_position);
+        assertEqual(video_position->x(), 10);
+        assertEqual(video_position->y(), 20);
+
+        auto video_rotate = dynamic_cast<const VideoRotate*>(effects[2].value);
+        assertNotNull(video_rotate);
+        assertEqual(video_rotate->angle(), 45.5);
+
+        auto video_crop = dynamic_cast<const VideoCrop*>(effects[3].value);
+        assertNotNull(video_crop);
+        assertEqual(video_crop->left(), 5);
+        assertEqual(video_crop->right(), 6);
+        assertEqual(video_crop->top(), 7);
+        assertEqual(video_crop->bottom(), 8);
+    });
+
+    tests.add_test("test_video_transform_write", [] {
+        using namespace otio;
+
+        SerializableObject::Retainer<otio::Clip> clip(new otio::Clip(
+            "unit_clip",
+            new otio::ExternalReference("unit_test_url"),
+            std::nullopt,
+            otio::AnyDictionary(),
+            { new otio::VideoScale("scale", 100, 120),
+              new otio::VideoPosition("position", 10, 20),
+              new otio::VideoRotate("rotate", 40.5),
+              new otio::VideoCrop("crop", 1, 2, 3, 4) }));
+
+        auto json = clip.value->to_json_string();
+
+        std::string expected_json = R"({
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": {},
+    "name": "unit_clip",
+    "source_range": null,
+    "effects": [
+        {
+            "OTIO_SCHEMA": "VideoScale.1",
+            "metadata": {},
+            "name": "scale",
+            "effect_name": "VideoScale",
+            "enabled": true,
+            "width": 100,
+            "height": 120
+        },
+        {
+            "OTIO_SCHEMA": "VideoPosition.1",
+            "metadata": {},
+            "name": "position",
+            "effect_name": "VideoPosition",
+            "enabled": true,
+            "x": 10,
+            "y": 20
+        },
+        {
+            "OTIO_SCHEMA": "VideoRotate.1",
+            "metadata": {},
+            "name": "rotate",
+            "effect_name": "VideoRotate",
+            "enabled": true,
+            "angle": 40.5
+        },
+        {
+            "OTIO_SCHEMA": "VideoCrop.1",
+            "metadata": {},
+            "name": "crop",
+            "effect_name": "VideoCrop",
+            "enabled": true,
+            "left": 1,
+            "right": 2,
+            "top": 3,
+            "bottom": 4
+        }
+    ],
+    "markers": [],
+    "enabled": true,
+    "media_references": {
+        "DEFAULT_MEDIA": {
+            "OTIO_SCHEMA": "ExternalReference.1",
+            "metadata": {},
+            "name": "",
+            "available_range": null,
+            "available_image_bounds": null,
+            "target_url": "unit_test_url"
+        }
+    },
+    "active_media_reference_key": "DEFAULT_MEDIA"
+})";
+
+        assertEqual(json, expected_json);
+
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}

--- a/tests/test_transform_effects.py
+++ b/tests/test_transform_effects.py
@@ -1,0 +1,265 @@
+"""Transform effects class test harness."""
+
+import unittest
+from fractions import Fraction
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+class VideoScaleTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_constructor(self):
+        scale = otio.schema.VideoScale(
+            name="ScaleIt",
+            width=100,
+            height=120,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertEqual(scale.width, 100)
+        self.assertEqual(scale.height, 120)
+        self.assertEqual(scale.name, "ScaleIt")
+        self.assertEqual(scale.metadata, {"foo": "bar"})
+
+    def test_eq(self):
+        scale1 = otio.schema.VideoScale(
+            name="ScaleIt",
+            width=120,
+            height=130,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        scale2 = otio.schema.VideoScale(
+            name="ScaleIt",
+            width=120,
+            height=130,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertIsOTIOEquivalentTo(scale1, scale2)
+
+    def test_serialize(self):
+        scale = otio.schema.VideoScale(
+            name="ScaleIt",
+            width=130,
+            height=140,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        encoded = otio.adapters.otio_json.write_to_string(scale)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(scale, decoded)
+
+    def test_setters(self):
+        scale = otio.schema.VideoScale(
+            name="ScaleIt",
+            width=140,
+            height=150,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertEqual(scale.width, 140)
+        scale.width = 100
+        self.assertEqual(scale.width,100)
+        self.assertEqual(scale.height, 150)
+        scale.height = 100
+        self.assertEqual(scale.height,100)
+
+class VideoCropTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        crop = otio.schema.VideoCrop(
+            name="CropIt",
+            left=2,
+            right=3,
+            top=4,
+            bottom=5,
+            metadata={
+                "baz": "qux"
+            }
+        )
+        self.assertEqual(crop.left, 2)
+        self.assertEqual(crop.right, 3)
+        self.assertEqual(crop.top, 4)
+        self.assertEqual(crop.bottom, 5)
+        self.assertEqual(crop.name, "CropIt")
+        self.assertEqual(crop.metadata, {"baz": "qux"})
+
+    def test_eq(self):
+        crop1 = otio.schema.VideoCrop(
+            name="CropIt",
+            left=2,
+            right=3,
+            top=4,
+            bottom=5,
+            metadata={
+                "baz": "qux"
+            }
+        )
+        crop2 = otio.schema.VideoCrop(
+            name="CropIt",
+            left=2,
+            right=3,
+            top=4,
+            bottom=5,
+            metadata={
+                "baz": "qux"
+            }
+        )
+        self.assertIsOTIOEquivalentTo(crop1, crop2)
+
+    def test_serialize(self):
+        crop = otio.schema.VideoCrop(
+            name="CropIt",
+            left=2,
+            right=3,
+            top=4,
+            bottom=5,
+            metadata={
+                "baz": "qux"
+            }
+        )
+        encoded = otio.adapters.otio_json.write_to_string(crop)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(crop, decoded)
+
+    def test_setters(self):
+        crop = otio.schema.VideoCrop(
+            name="CropIt",
+            left=2,
+            right=3,
+            top=4,
+            bottom=5,
+            metadata={
+                "baz": "qux"
+            }
+        )
+        self.assertEqual(crop.left, 2)
+        crop.left = 1
+        self.assertEqual(crop.left, 1)
+        crop.right = 3
+        self.assertEqual(crop.right, 3)
+        crop.top = 4
+        self.assertEqual(crop.top, 4)
+        crop.bottom = 7
+        self.assertEqual(crop.bottom, 7)
+
+class VideoPositionTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_constructor(self):
+        position = otio.schema.VideoPosition(
+            name="PositionIt",
+            x=11,
+            y=12,
+            metadata={
+                "alpha": "beta"
+            }
+        )
+        self.assertEqual(position.x, 11)
+        self.assertEqual(position.y, 12)
+        self.assertEqual(position.name, "PositionIt")
+        self.assertEqual(position.metadata, {"alpha": "beta"})
+
+    def test_eq(self):
+        pos1 = otio.schema.VideoPosition(
+            name="PositionIt",
+            x=11,
+            y=12,
+            metadata={
+                "alpha": "beta"
+            }
+        )
+        pos2 = otio.schema.VideoPosition(
+            name="PositionIt",
+            x=11,
+            y=12,
+            metadata={
+                "alpha": "beta"
+            }
+        )
+        self.assertIsOTIOEquivalentTo(pos1, pos2)
+
+    def test_serialize(self):
+        position = otio.schema.VideoPosition(
+            name="PositionIt",
+            x=11,
+            y=12,
+            metadata={
+                "alpha": "beta"
+            }
+        )
+        encoded = otio.adapters.otio_json.write_to_string(position)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(position, decoded)
+
+    def test_setters(self):
+        position = otio.schema.VideoPosition(
+            name="PositionIt",
+            x=11,
+            y=12,
+            metadata={
+                "alpha": "beta"
+            }
+        )
+        self.assertEqual(position.x, 11)
+        position.x = 1
+        self.assertEqual(position.x, 1)
+        self.assertEqual(position.y, 12)
+        position.y = 2
+        self.assertEqual(position.y, 2)
+
+class VideoRotateTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_constructor(self):
+        rotate = otio.schema.VideoRotate(
+            name="RotateIt",
+            angle=45.25,
+            metadata={
+                "rot": "val"
+            }
+        )
+        self.assertEqual(rotate.angle,45.25)
+        self.assertEqual(rotate.name, "RotateIt")
+        self.assertEqual(rotate.metadata, {"rot": "val"})
+
+    def test_eq(self):
+        rot1 = otio.schema.VideoRotate(
+            name="RotateIt",
+            angle=45.25,
+            metadata={
+                "rot": "val"
+            }
+        )
+        rot2 = otio.schema.VideoRotate(
+            name="RotateIt",
+            angle=45.25,
+            metadata={
+                "rot": "val"
+            }
+        )
+        self.assertIsOTIOEquivalentTo(rot1, rot2)
+
+    def test_serialize(self):
+        rotate = otio.schema.VideoRotate(
+            name="RotateIt",
+            angle=45.25,
+            metadata={
+                "rot": "val"
+            }
+        )
+        encoded = otio.adapters.otio_json.write_to_string(rotate)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(rotate, decoded)
+
+    def test_setters(self):
+        rotate = otio.schema.VideoRotate(
+            name="RotateIt",
+            angle=45.25,
+            metadata={
+                "rot": "val"
+            }
+        )
+        self.assertEqual(rotate.angle, 45.25)
+        rotate.angle = 90.0
+        self.assertEqual(rotate.angle, 90.0)

--- a/tests/test_volume_effects.cpp
+++ b/tests/test_volume_effects.cpp
@@ -1,0 +1,140 @@
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/deserialization.h>
+#include <opentimelineio/externalReference.h>
+#include <opentimelineio/volumeEffects.h>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+    tests.add_test("test_audio_volume_read", [] {
+        using namespace otio;
+
+        otio::ErrorStatus              status;
+        SerializableObject::Retainer<> so =
+            SerializableObject::from_json_string(
+                R"(
+            {
+                "OTIO_SCHEMA": "Clip.1",
+                "media_reference": {
+                    "OTIO_SCHEMA": "ExternalReference.1",
+                    "target_url": "unit_test_url",
+                    "available_range": {
+                        "OTIO_SCHEMA": "TimeRange.1",
+                        "duration": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24,
+                            "value": 8
+                        },
+                        "start_time": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24,
+                            "value": 10
+                        }
+                    }
+                },
+                "effects": [
+                    {
+                        "OTIO_SCHEMA": "AudioVolume.1",
+                        "name": "volume",
+                        "gain": 0.5,
+                        "effect_name": "AudioVolume",
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "AudioFade.1",
+                        "name": "fade",
+                        "fade_in": false,
+                        "start_time": 1.5,
+                        "duration": 5.0,
+                        "effect_name": "AudioFade",
+                        "enabled": true
+                    }
+                ]
+            })",
+                &status);
+
+        assertFalse(is_error(status));
+
+        const Clip* clip = dynamic_cast<const Clip*>(so.value);
+        assertNotNull(clip);
+
+        auto effects = clip->effects();
+        assertEqual(effects.size(), 2);
+
+        auto audio_volume = dynamic_cast<const AudioVolume*>(effects[0].value);
+        assertNotNull(audio_volume);
+        assertEqual(audio_volume->gain(), 0.5);
+
+        auto audio_fade = dynamic_cast<const AudioFade*>(effects[1].value);
+        assertNotNull(audio_fade);
+        assertEqual(audio_fade->fade_in(), false);
+        assertEqual(audio_fade->start_time(), 1.5);
+        assertEqual(audio_fade->duration(), 5.0);
+    });
+
+    tests.add_test("test_audio_volume_write", [] {
+        using namespace otio;
+
+        SerializableObject::Retainer<otio::Clip> clip(new otio::Clip(
+            "unit_clip",
+            new otio::ExternalReference("unit_test_url"),
+            std::nullopt,
+            otio::AnyDictionary(),
+            { new otio::AudioVolume("volume", 0.75),
+              new otio::AudioFade("fade", true, 2.0, 10.5)}));
+
+        auto json = clip.value->to_json_string();
+
+        std::string expected_json = R"({
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": {},
+    "name": "unit_clip",
+    "source_range": null,
+    "effects": [
+        {
+            "OTIO_SCHEMA": "AudioVolume.1",
+            "metadata": {},
+            "name": "volume",
+            "effect_name": "AudioVolume",
+            "enabled": true,
+            "gain": 0.75
+        },
+        {
+            "OTIO_SCHEMA": "AudioFade.1",
+            "metadata": {},
+            "name": "fade",
+            "effect_name": "AudioFade",
+            "enabled": true,
+            "fade_in": true,
+            "start_time": 2.0,
+            "duration": 10.5
+        }
+    ],
+    "markers": [],
+    "enabled": true,
+    "media_references": {
+        "DEFAULT_MEDIA": {
+            "OTIO_SCHEMA": "ExternalReference.1",
+            "metadata": {},
+            "name": "",
+            "available_range": null,
+            "available_image_bounds": null,
+            "target_url": "unit_test_url"
+        }
+    },
+    "active_media_reference_key": "DEFAULT_MEDIA"
+})";
+
+        assertEqual(json, expected_json);
+
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}

--- a/tests/test_volume_effects.py
+++ b/tests/test_volume_effects.py
@@ -1,0 +1,122 @@
+"""Volume effects class test harness."""
+
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+class AudioVolumeTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_constructor(self):
+        scale = otio.schema.AudioVolume(
+            name="volume",
+            gain=2.5,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertEqual(scale.gain, 2.5)
+        self.assertEqual(scale.name, "volume")
+        self.assertEqual(scale.metadata, {"foo": "bar"})
+
+    def test_eq(self):
+        scale1 = otio.schema.AudioVolume(
+            name="volume",
+            gain=2.5,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        scale2 = otio.schema.AudioVolume(
+            name="volume",
+            gain=2.5,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertIsOTIOEquivalentTo(scale1, scale2)
+
+    def test_serialize(self):
+        scale = otio.schema.AudioVolume(
+            name="volume",
+            gain=0.6,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        encoded = otio.adapters.otio_json.write_to_string(scale)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(scale, decoded)
+
+    def test_setters(self):
+        scale = otio.schema.AudioVolume(
+            name="volume",
+            gain=0.8,
+            metadata={
+                "foo": "bar"
+            }
+        )
+        self.assertEqual(scale.gain, 0.8)
+        scale.gain = 0.25
+        self.assertEqual(scale.gain, 0.25)
+
+class AudioFadeTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_constructor(self):
+        fade = otio.schema.AudioFade(
+            name="fade",
+            fade_in=True,
+            start_time=12.0,
+            duration=8.0,
+            metadata={"baz": "qux"}
+        )
+        self.assertEqual(fade.name, "fade")
+        self.assertEqual(fade.fade_in, True)
+        self.assertEqual(fade.start_time, 12.0)
+        self.assertEqual(fade.duration, 8.0)
+        self.assertEqual(fade.metadata, {"baz": "qux"})
+
+    def test_eq(self):
+        fade1 = otio.schema.AudioFade(
+            name="fade",
+            fade_in=False,
+            start_time=5.0,
+            duration=3.0,
+            metadata={"baz": "qux"}
+        )
+        fade2 = otio.schema.AudioFade(
+            name="fade",
+            fade_in=False,
+            start_time=5.0,
+            duration=3.0,
+            metadata={"baz": "qux"}
+        )
+        self.assertIsOTIOEquivalentTo(fade1, fade2)
+
+    def test_serialize(self):
+        fade = otio.schema.AudioFade(
+            name="fade",
+            fade_in=True,
+            start_time=2.5,
+            duration=1.5,
+            metadata={"baz": "qux"}
+        )
+        encoded = otio.adapters.otio_json.write_to_string(fade)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(fade, decoded)
+
+    def test_setters(self):
+        fade = otio.schema.AudioFade(
+            name="fade",
+            fade_in=False,
+            start_time=4.0,
+            duration=2.0,
+            metadata={"baz": "qux"}
+        )
+        self.assertEqual(fade.fade_in, False)
+        self.assertEqual(fade.start_time, 4.0)
+        self.assertEqual(fade.duration, 2.0)
+        fade.fade_in = True
+        fade.start_time = 7.5
+        fade.duration = 3.5
+        self.assertEqual(fade.fade_in, True)
+        self.assertEqual(fade.start_time, 7.5)
+        self.assertEqual(fade.duration, 3.5)


### PR DESCRIPTION
[RIV-97269](https://riversidefm.atlassian.net/browse/RIV-97269)
[RIV-97311](https://riversidefm.atlassian.net/browse/RIV-97311)

This adds the following effects:
- VideoScale
- VideoCrop
- VideoRotate
- VideoPosition
- AudioVolume
- AudioFade

Also adds canvas size to Timeline and bumps schema to 2

Unit tests added/updated