### PR TITLE
Memoization of range calculation

### DIFF
--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -98,6 +98,7 @@ Composition::insert_child(
     }
 
     _child_set.insert(child);
+    invalidate_cache();
     return true;
 }
 
@@ -130,6 +131,7 @@ Composition::set_child(int index, Composable* child, ErrorStatus* error_status)
         child->_set_parent(this);
         _children[index] = child;
         _child_set.insert(child);
+        invalidate_cache();
     }
     return true;
 }
@@ -161,6 +163,7 @@ Composition::remove_child(int index, ErrorStatus* error_status)
         _children[index]->_set_parent(nullptr);
         _children.erase(_children.begin() + index);
     }
+    invalidate_cache();
 
     return true;
 }

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -158,6 +158,9 @@ public:
         std::optional<TimeRange> search_range   = std::nullopt,
         bool                     shallow_search = false) const;
 
+
+    virtual void invalidate_cache() const {};
+
 protected:
     virtual ~Composition();
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -189,4 +189,10 @@ Stack::available_image_bounds(ErrorStatus* error_status) const
     return box;
 }
 
+void
+Stack::invalidate_cache() const
+{
+    _availableRangeCache = std::nullopt;
+    _childRangesCacche.clear();
+}
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -41,12 +41,12 @@ Stack::write_to(Writer& writer) const
 TimeRange
 Stack::range_of_child_at_index(int index, ErrorStatus* error_status) const
 {
+    index = adjusted_vector_index(index, children());
     auto it = _childRangesCacche.find(index);
     if (it != _childRangesCacche.end()) {
         return it->second;
     }
 
-    index = adjusted_vector_index(index, children());
     if (index < 0 || index >= int(children().size()))
     {
         if (error_status)

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -41,6 +41,11 @@ Stack::write_to(Writer& writer) const
 TimeRange
 Stack::range_of_child_at_index(int index, ErrorStatus* error_status) const
 {
+    auto it = _childRangesCacche.find(index);
+    if (it != _childRangesCacche.end()) {
+        return it->second;
+    }
+
     index = adjusted_vector_index(index, children());
     if (index < 0 || index >= int(children().size()))
     {
@@ -48,6 +53,7 @@ Stack::range_of_child_at_index(int index, ErrorStatus* error_status) const
         {
             *error_status = ErrorStatus::ILLEGAL_INDEX;
         }
+        _childRangesCacche[index] = TimeRange();
         return TimeRange();
     }
 
@@ -55,10 +61,13 @@ Stack::range_of_child_at_index(int index, ErrorStatus* error_status) const
     auto        duration = child->duration(error_status);
     if (is_error(error_status))
     {
+        _childRangesCacche[index] = TimeRange();
         return TimeRange();
     }
 
-    return TimeRange(RationalTime(0, duration.rate()), duration);
+    auto result = TimeRange(RationalTime(0, duration.rate()), duration);
+    _childRangesCacche[index] = result;
+    return result;
 }
 
 std::map<Composable*, TimeRange>
@@ -118,9 +127,14 @@ Stack::trimmed_range_of_child_at_index(int index, ErrorStatus* error_status)
 TimeRange
 Stack::available_range(ErrorStatus* error_status) const
 {
+    if (_availableRangeCache.has_value()) {
+        return _availableRangeCache.value();
+    }
+
     if (children().empty())
     {
-        return TimeRange();
+        _availableRangeCache = TimeRange();
+        return _availableRangeCache.value();
     }
 
     auto duration = children()[0].value->duration(error_status);
@@ -130,7 +144,8 @@ Stack::available_range(ErrorStatus* error_status) const
             std::max(duration, children()[i].value->duration(error_status));
     }
 
-    return TimeRange(RationalTime(0, duration.rate()), duration);
+    _availableRangeCache = TimeRange(RationalTime(0, duration.rate()), duration);
+    return _availableRangeCache.value();
 }
 
 std::vector<SerializableObject::Retainer<Clip>>

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -76,6 +76,9 @@ protected:
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;
+
+    mutable std::unordered_map<int, TimeRange> _childRangesCacche;
+    mutable std::optional<TimeRange> _availableRangeCache;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -69,6 +69,9 @@ public:
         std::optional<TimeRange> const& search_range   = std::nullopt,
         bool                            shallow_search = false) const;
 
+
+
+    void invalidate_cache() const override;
 protected:
     virtual ~Stack();
 

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -321,4 +321,11 @@ Track::available_image_bounds(ErrorStatus* error_status) const
     return box;
 }
 
+void
+Track::invalidate_cache() const
+{
+    _availableRangeCache = std::nullopt;
+    _childRangesCacche.clear();
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -44,12 +44,12 @@ Track::write_to(Writer& writer) const
 TimeRange
 Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
 {
+    index = adjusted_vector_index(index, children());
     auto it = _childRangesCacche.find(index);
     if (it != _childRangesCacche.end()) {
         return it->second;
     }
 
-    index = adjusted_vector_index(index, children());
     if (index < 0 || index >= int(children().size()))
     {
         if (error_status)

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -44,6 +44,11 @@ Track::write_to(Writer& writer) const
 TimeRange
 Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
 {
+    auto it = _childRangesCacche.find(index);
+    if (it != _childRangesCacche.end()) {
+        return it->second;
+    }
+
     index = adjusted_vector_index(index, children());
     if (index < 0 || index >= int(children().size()))
     {
@@ -51,6 +56,7 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
         {
             *error_status = ErrorStatus::ILLEGAL_INDEX;
         }
+        _childRangesCacche[index] = TimeRange();
         return TimeRange();
     }
 
@@ -58,6 +64,7 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
     RationalTime child_duration = child->duration(error_status);
     if (is_error(error_status))
     {
+        _childRangesCacche[index] = TimeRange();
         return TimeRange();
     }
 
@@ -72,6 +79,7 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
         }
         if (is_error(error_status))
         {
+            _childRangesCacche[index] = TimeRange();
             return TimeRange();
         }
     }
@@ -81,7 +89,9 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
         start_time -= transition->in_offset();
     }
 
-    return TimeRange(start_time, child_duration);
+    auto result = TimeRange(start_time, child_duration);
+    _childRangesCacche[index] = result;
+    return result;
 }
 
 TimeRange
@@ -110,6 +120,10 @@ Track::trimmed_range_of_child_at_index(int index, ErrorStatus* error_status)
 TimeRange
 Track::available_range(ErrorStatus* error_status) const
 {
+    if (_availableRangeCache.has_value()) {
+        return _availableRangeCache.value();
+    }
+
     RationalTime duration;
     for (const auto& child: children())
     {
@@ -118,7 +132,8 @@ Track::available_range(ErrorStatus* error_status) const
             duration += item->duration(error_status);
             if (is_error(error_status))
             {
-                return TimeRange();
+                _availableRangeCache = TimeRange();
+                return _availableRangeCache.value();
             }
         }
     }
@@ -137,7 +152,8 @@ Track::available_range(ErrorStatus* error_status) const
         }
     }
 
-    return TimeRange(RationalTime(0, duration.rate()), duration);
+    _availableRangeCache = TimeRange(RationalTime(0, duration.rate()), duration);
+    return _availableRangeCache.value();
 }
 
 std::pair<std::optional<RationalTime>, std::optional<RationalTime>>

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -92,6 +92,8 @@ public:
         std::optional<TimeRange> const& search_range   = std::nullopt,
         bool                            shallow_search = false) const;
 
+    void invalidate_cache() const override;
+
 protected:
     virtual ~Track();
 

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -102,6 +102,8 @@ protected:
 
 private:
     std::string _kind;
+    mutable std::unordered_map<int, TimeRange> _childRangesCacche;
+    mutable std::optional<TimeRange> _availableRangeCache;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION


### PR DESCRIPTION
Accessing the range functions of the timeline is extremely slow because most of the functions traverse all the children, requesting their ranges. In this pull request, we are memoizing the results of these calculations. However, we assume that the children added to the tree remain unchanged after creation. This significantly improves performance on large timelines.