### PR TITLE
Invalidate caches in unit tests

### DIFF
--- a/src/opentimelineio/timeline.cpp
+++ b/src/opentimelineio/timeline.cpp
@@ -90,4 +90,27 @@ Timeline::find_clips(
         shallow_search);
 }
 
+void
+Timeline::invalidate_cache() const
+{
+    std::stack<Composition*> stack;
+    stack.push(_tracks.value);
+    while (!stack.empty())
+    {
+        auto composition = stack.top();
+        composition->invalidate_cache();
+
+        stack.pop();
+
+        for (auto child : composition->children())
+        {
+            auto* next_composition = dynamic_cast<Composition*>(child.value);
+            if (next_composition)
+            {
+                stack.push(next_composition);
+            }
+        }
+    }
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -124,6 +124,9 @@ public:
         return _tracks.value->available_image_bounds(error_status);
     }
 
+    /// @brief Invalidate the cache.
+    void invalidate_cache() const;
+
 protected:
     virtual ~Timeline();
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -663,7 +663,8 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
             }, "search_range"_a = std::nullopt, "shallow_search"_a = false)
         .def("find_children", [](Timeline* t, py::object descended_from_type, std::optional<TimeRange> const& search_range, bool shallow_search) {
                 return find_children(t, descended_from_type, search_range, shallow_search);
-            }, "descended_from_type"_a = py::none(), "search_range"_a = std::nullopt, "shallow_search"_a = false);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = std::nullopt, "shallow_search"_a = false)
+        .def("invalidate_cache", &Timeline::invalidate_cache);
 }
 
 static void define_effects(py::module m) {

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1895,6 +1895,7 @@ class NestingTest(unittest.TestCase):
             wrapper = _nest(self, clip)
             wrappers.append(wrapper)
 
+        timeline.invalidate_cache()
         # nothing should have shifted at all
 
         # print otio.adapters.otio_json.write_to_string(timeline)
@@ -1927,6 +1928,8 @@ class NestingTest(unittest.TestCase):
             wrapper.source_range = trim
 
         # print otio.adapters.otio_json.write_to_string(timeline)
+
+        timeline.invalidate_cache()
 
         # the clip should be the same
         self.assertEqual(clip.duration(), onehundred)


### PR DESCRIPTION
Python unit tests fail due to cached time ranges and mutable timelines.

Add a top level invalidator and call it to make tests pass again.