### PR TITLE
Fix build by including stack header

### DIFF
--- a/src/opentimelineio/timeline.cpp
+++ b/src/opentimelineio/timeline.cpp
@@ -4,6 +4,8 @@
 #include "opentimelineio/timeline.h"
 #include "opentimelineio/clip.h"
 
+#include <stack>
+
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 Timeline::Timeline(


### PR DESCRIPTION
Build was failing because we are using `std::stack` without the include